### PR TITLE
disabled delay for people not explicitly using it

### DIFF
--- a/.homebridge-dev/config.json
+++ b/.homebridge-dev/config.json
@@ -33,6 +33,7 @@
             "service": "Switch",
             "name": "Switch",
             "debug" : true,
+            "setterDelay": 5000,
             "urls":{
                 "getOn": {
                     "url" : "http://urlecho.appspot.com/echo?status=200&Content-Type=text%2Fhtml&body={\"value\":1}",
@@ -46,7 +47,55 @@
                     ]
                 },
                 "setOn":{
-                    "url" : "http://urlecho.appspot.com/echo?status=200&Content-Type=text%2Fhtml&body={\"value\":${value}"
+                    "url" : "http://111urlecho.appspot.com/echo?status=200&Content-Type=text%2Fhtml&body={\"value\":${value}"
+                }
+            }
+        },
+        {
+            "accessory": "HttpAdvancedAccessory",
+            "service": "WindowCovering",
+            "name": "Kitchen Blinds",
+            "debug": true,
+            "setterDelay": 5000,
+            "forceRefreshDelay": 10,
+            "polling": true,
+            "optionCharacteristic": [],
+            "urls": {
+                "getCurrentPosition": {
+                    "url": "http://urlecho.appspot.com/echo?status=200&Content-Type=text%2Fhtml&body={\"value\":1}",
+                    "httpMethod": "GET",
+                    "mappers": [
+                        {
+                            "type": "jpath",
+                            "parameters": {
+                                "jpath": "$.value"
+                            }
+                        }
+                    ]
+                },
+                "getTargetPosition": {
+                    "url": "http://urlecho.appspot.com/echo?status=200&Content-Type=text%2Fhtml&body={\"value\":10}",
+                    "httpMethod": "GET",
+                    "mappers": [
+                        {
+                            "type": "jpath",
+                            "parameters": {
+                                "jpath": "$.value"
+                            }
+                        }
+                    ]
+                },
+                "setTargetPosition": {
+                    "url": "http://urlecho.appspot.com/echo?status=200&Content-Type=text%2Fhtml&body={\"value\":{value}}",
+                    "httpMethod": "GET",
+                    "mappers": [
+                        {
+                            "type": "jpath",
+                            "parameters": {
+                                "jpath": "$.value"
+                            }
+                        }
+                    ]
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Configuration sample:
 - The **urls section** configures the URLs that are to be called on certain events. It contains a key-value map of actions that can be executed. The key is name of the action and the value is a configuration JSON object for that action. See the [Actions](#actions) section below.
 - The **polling** is a boolean that specifies if the current state should be pulled on regular intervals or not. Defaults to false.
 - **forceRefreshDelay** is a number which defines the poll interval in seconds. Defaults to 0.
-- **setterDelay** is a number which defines the number of milliseconds to wait before executing a "set" action request. If more than one request is received during this interval, only the last one is executed. Defaults to 200.
+- **setterDelay** is a number which defines the number of milliseconds to wait before executing a "set" action request. If more than one request is received during this interval, only the last one is executed. Defaults to 0 - disabled.
 
 ## Actions
 

--- a/index.js
+++ b/index.js
@@ -402,7 +402,7 @@ HttpAdvancedAccessory.prototype = {
 					}
 				},
 				setter: function (value, callback) { 
-					if (this.enableSet == false || setterDelay === 0) {
+					if (this.enableSet == false || this.setterDelay === 0) {
 						// no setter delay or internal set - do it immediately 
 						this.debugLog("updating " + characteristic.displayName.replace(/\s/g, '') + " with value " + value);
 						setDispatch(value, callback, characteristic);


### PR DESCRIPTION
known issue: due to the optimistic setter callback, if the http request returns an error, you can't send it back to homekit. this only happens if you use the delayed setter