### PR TITLE
DisplayName and JSON catch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # homebridge http advanced accessory
 
-Homebridge plugin that can turn virtually any device which exposes HTTP APIs into an HomeKit compatible Service.
+Homebridge plugin that can turn virtually any device which exposes HTTP APIs into an HomeKit-compatible Service.
 Its purpose is to connect any device that can be controlled via HTTP command to Homekit. It creates a Homebridge accessory which uses HTTP calls to *change* and *check* its state via [Actions](#actions).
 
 This plugin is a fork of HttpAccessory and has merged many features (mainly mappers) from the [homebridge-http-securitysystem](<https://www.npmjs.com/package/homebridge-http-securitysystem>).
@@ -118,7 +118,7 @@ Configuration sample:
 - The **service** parameter determines the kind of Service\Accessory you will see in HomeKit.
 - The **username/password** configuration can be used to specify the username and password if the remote webserver requires HTTP authentication.
 - A **debug** turns on debug messages. The important bit is that it reports the mapping process so that it's easier to debug.
-- The **optionCharacteristic** is an array of optional Characteristic of the service that you want to expose to HomeKit. The full list of mandatory and optional Characteristics types that HomeKit supports are exposed as a separate subclass in [HomeKitTypes](https://github.com/homebridge/HAP-NodeJS/blob/master/src/lib/gen/HomeKit.ts).
+- The **optionCharacteristic** is an array of optional Characteristics of the service that you want to expose to HomeKit. The full list of mandatory and optional Characteristics types that HomeKit supports are exposed as a separate subclass in [HomeKitTypes](https://github.com/homebridge/HAP-NodeJS/blob/master/src/lib/gen/HomeKit.ts).
 - The **urls section** configures the URLs that are to be called on certain events. It contains a key-value map of actions that can be executed. The key is name of the action and the value is a configuration JSON object for that action. See the [Actions](#actions) section below.
 - The **polling** is a boolean that specifies if the current state should be pulled on regular intervals or not. Defaults to false.
 - **forceRefreshDelay** is a number which defines the poll interval in seconds. Defaults to 0.
@@ -127,13 +127,13 @@ Configuration sample:
 
 ## Actions
 
-The action is a key-value map that configures the URLs to be called to perform a read or a write on a particular Charateristic. In fact, there are two kind of actions, getters and setters: actions for getter keys begin with word "get", actions for the setters begin with "set".
+The action is a key-value map that configures the URLs to be called to perform a read or a write on a particular Characteristic. In fact, there are two kind of actions, getters and setters: actions for getter keys begin with word "get", actions for the setters begin with "set".
 So the key name is composed of two parts:
 
 - The kind of action: "get" or "set"
 - The name of the HomeKit Characteristics for that Service. All known built-in Service and Characteristic types that HomeKit supports are exposed as a separate subclass in [HomeKitTypes](https://github.com/homebridge/HAP-NodeJS/blob/master/src/lib/gen/HomeKit.ts).
 
-For example to get the value of the SecuritySystemTargetState Characteristic, the key value would be "getSecuritySystemTargetState" while to set it, "setSecuritySystemTargetState"
+For example, to get the value of the SecuritySystemTargetState Characteristic, the key value would be "getSecuritySystemTargetState"—while to set it, "setSecuritySystemTargetState"
 
 ### Getter Action
 
@@ -178,16 +178,16 @@ The value object has the following JSON format for a **setter** action:
 
 Where:
 
-- The **url** parameter is the url to be called for that action. If the string contains the "{value}" placeholder, it will be replaced by the value that HomeKit wants to set, after being changed parsed by mappers. The url can also be a string template, see [URL Template](#url-template)
+- The **url** parameter is the URL to be called for that action. If the string contains the "{value}" placeholder, it will be replaced by the value that HomeKit wants to set, after being changed parsed by mappers. The url can also be a string template, see [URL Template](#url-template)
 - The **httpMethod** (OPTIONAL) parameter is one of "GET" or "POST". Defaults to "GET".
 - The **body** (OPTIONAL) parameter is the body of the HTTP POST call.
-- The **mappers** (OPTIONAL) are a chain of blocks that have the purpose of changing the value that HomeKit wants to set to something that is valid for your device,  see [Mapping](#mapping)
+- The **mappers** (OPTIONAL) are a chain of blocks that have the purpose of changing the value that HomeKit wants to set to something that is valid for your device, see [Mapping](#mapping)
 
 ### URL Template
 
-The URL can be a [string template](<http://exploringjs.com/es6/ch_template-literals.html>) so you can use esxpressions like *$(state.getCurrentTemperaure)* that will be replaced by the current value of the Charateristic CurrentTemperature.
-The *state* variable contains all the values of the Charateristics of the Service, plus the *value* variable contains the value HK wants to set for the Charateristic being setted.
-For example suppose that when setting the Active state of a HeatingCooling system it also needs to set the TargetTemperature in fahrenheit you may have something like this:
+The URL can be a [string template](<http://exploringjs.com/es6/ch_template-literals.html>) so you can use expressions like *$(state.getCurrentTemperature)* that will be replaced by the current value of the Characteristic CurrentTemperature.
+The *state* variable contains all the values of the Characteristics of the Service, plus the *value* variable contains the value HK wants to set for the Characteristic being set.
+For example, suppose that when setting the Active state of a HeatingCooling system it also needs to set the TargetTemperature in Fahrenheit—you may have something like this:
 
 ```json
 "setActive" : {
@@ -199,7 +199,7 @@ For example suppose that when setting the Active state of a HeatingCooling syste
 
 ### Mapping
 
-The mappings block of the configuration may contain any number of mapper definitions. The mappers are chained after each other,  the result of a mapper is fed into the input of the next mapper. The purpose of this whole chain is to somehow boil down the response received from the API to a single value which is expected by Homekit.
+The mappings block of the configuration may contain any number of mapper definitions. The mappers are chained after each other—the result of a mapper is fed into the input of the next mapper. The purpose of this whole chain is to somehow boil down the response received from the API to a single value which is expected by HomeKit.
 
 Each mapper has the following JSON format:
 
@@ -320,7 +320,7 @@ In this case this mapper will return "ARMED_IMMEDIATE". The ***index*** paramete
 
 #### Eval mapper
 
-The eval mapper can be used to run any javascript code, which will be interpreted when the event is called. Use `value` to use the set/read value in your code.
+The eval mapper can be used to run any JavaScript code, which will be interpreted when the event is called. Use `value` to use the set/read value in your code.
 
 Configuration is as follows:
 
@@ -378,9 +378,9 @@ TunneledBTLEAccessoryService
 Window
 WindowCovering  
 
-## Configuration Example
+## Configuration Examples
 
-The purpose of this section is collect as many configuration example as possible.
+The purpose of this section is collect as many configuration examples as possible.
 
 ### Bticino "Nuovo antifurto filare"
 
@@ -557,9 +557,119 @@ This is still incomplete but the unofficial [Daikin documentation](https://githu
 
 ```
 
-## Plugin development
+### Generic Web API as Lightbulb
 
-To aid in testing and developing this plugin further I have provided a sample hombridge config. This will allow you to spin a homebridge instance for development that has this plugin already installed.  
+```json
+{
+    "accessory": "HttpAdvancedAccessory",
+    "service": "Lightbulb",
+    "name": "Pool Light",
+    "manufacturer": "Custom",
+    "model": "Virtual Device",
+    "debug": false,
+    "optionCharacteristic": [
+        "Hue",
+        "Saturation",
+        "Brightness"
+    ],
+    "urls": {
+        "setOn": {
+            "httpMethod": "POST",
+            "body": "%7B%22c%22%3A%22pool%20i%20{value}%22%7D",
+            "url": "http://127.0.0.1/control.php",
+            "mappers": [
+                {
+                    "type": "static",
+                    "parameters": {
+                        "mapping": {
+                            "true": "on",
+                            "false": "off"
+                        }
+                    }
+                }
+            ]
+        },
+        "getOn": {
+            "httpMethod": "POST",
+            "body": "%7B%22c%22%3A%22update%20pool-on%22%7D",
+            "url": "http://127.0.0.1/control.php",
+            "mappers": [
+                {
+                    "type": "jpath",
+                    "parameters": {
+                        "jpath": "$.u",
+                        "index": 0
+                    }
+                }
+            ]
+        },
+        "setHue": {
+            "httpMethod": "POST",
+            "url": "http://127.0.0.1/control.php",
+            "body": "%7B%22c%22%3A%22pool%20hue%20{value}%22%7D",
+            "mappers": []
+        },
+        "getHue": {
+            "httpMethod": "POST",
+            "url": "http://127.0.0.1/control.php",
+            "body": "%7B%22c%22%3A%22value%20pool-h%22%7D",
+            "mappers": [
+                {
+                    "type": "jpath",
+                    "parameters": {
+                        "jpath": "$.u",
+                        "index": 0
+                    }
+                }
+            ]
+        },
+        "setSaturation": {
+            "httpMethod": "POST",
+            "url": "http://127.0.0.1/control.php",
+            "body": "%7B%22c%22%3A%22pool%20saturation%20{value}%22%7D",
+            "mappers": []
+        },
+        "getSaturation": {
+            "httpMethod": "POST",
+            "url": "http://127.0.0.1/control.php",
+            "body": "%7B%22c%22%3A%22value%20pool-s%22%7D",
+            "mappers": [
+                {
+                    "type": "jpath",
+                    "parameters": {
+                        "jpath": "$.u",
+                        "index": 0
+                    }
+                }
+            ]
+        },
+        "setBrightness": {
+            "httpMethod": "POST",
+            "url": "http://127.0.0.1/control.php",
+            "body": "%7B%22c%22%3A%22pool%20brightness%20{value}%22%7D",
+            "mappers": []
+        },
+        "getBrightness": {
+            "httpMethod": "POST",
+            "url": "http://127.0.0.1/control.php",
+            "body": "%7B%22c%22%3A%22value%20pool-b%22%7D",
+            "mappers": [
+                {
+                    "type": "jpath",
+                    "parameters": {
+                        "jpath": "$.u",
+                        "index": 0
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+
+## Plugin Development
+
+To aid in testing and developing this plugin further I have provided a sample homebridge config. This will allow you to spin a homebridge instance for development that has this plugin already installed.  
 Install homebridge, checkout this repo and run: 
 ```sh
 $ homebridge --debug --user-storage-path .homebridge-dev --plugin-path ./ 

--- a/index.js
+++ b/index.js
@@ -227,10 +227,15 @@ HttpAdvancedAccessory.prototype = {
 					this.debugLog("received response from action: %s", action.url);
 					var state = responseBody;
 					state = this.applyMappers(action.mappers,state);
-					if(state == "inconclusive" && action.inconclusive){
-						this.debugLog("response inconclusive, try again.");
-						getDispatch(callback,action.inconclusive);
-					}else{
+					if (state == "inconclusive") {
+					   this.log(`Inconclusive mapping of response "${responseBody}"`);
+					   if (action.inconclusive){
+					     this.debugLog("Response inconclusive and trying the action specified for this condition.");
+					     getDispatch(callback,action.inconclusive);
+					   } else {
+					     this.debugLog("Response inconclusive with no further action specified for this condition.");
+					     }
+					} else {
 						this.debugLog("We have a value: %s, int: %d", state, parseInt(state));
 						callback(null, state);
 					}

--- a/mappers.js
+++ b/mappers.js
@@ -82,21 +82,31 @@ function JPathMapper(parameters) {
 	var self = this;
 	self.jpath = parameters.jpath;
 	self.index = parameters.index || 0;
-
+        
 	self.map = function(value) {
-		var json = JSON.parse(value);
-		var result  = JSONPath({path: self.jpath, json: json});
+	  var result = 'inconclusive';
+	  var json;
+	  
+	  try {
+	    json = JSON.parse(value);
+	    } catch (e) {
+	    return result;
+	    }
 
-		if (result instanceof Array && result.length > self.index) {
-			result = result[self.index];
-		}
-		
-		if (result instanceof Object) {
-			return JSON.stringify(result);
-		}
+        if (typeof json !== 'object') {
+          return result;
+        } else {
+          result = JSONPath({path: self.jpath, json: json});
+          if (result instanceof Array && result.length > self.index) {
+	        result = result[self.index];
+	        }
+	      if (result instanceof Object) {
+	        result = JSON.stringify(result);
+	        }
+	      }
 
-		return result;
-	};
+	return result;
+	}
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "HTTP Advanced Accessory",
   "name": "homebridge-http-advanced-accessory",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "http plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "displayName": "HTTP Advanced Accessory",
   "name": "homebridge-http-advanced-accessory",
   "version": "1.2.1",
   "description": "http plugin for homebridge: https://github.com/nfarina/homebridge",


### PR DESCRIPTION
Added "displayName" to package.json to display as "HTTP Advanced Accessory" in the Homebridge UI.

Some code in index.js and mappers.js to catch bad external JSON data from crashing Homebridge (fix of Unexpected token M in JSON at position 0 #29; see issue for code; tested for 12 months).