### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,38 @@ This is still incomplete but the unofficial [Daikin documentation](https://githu
 }
 ```
 
+### Vera EDGE Zwave on-off switch example for a device number 33
+
+```json
+{
+    "accessory": "HttpAdvancedAccessory",
+    "service": "Switch",
+    "name": "My lamp",
+    "forceRefreshDelay": 5,
+    "debug": false,
+    "urls": { 
+        "getOn": {
+            "url": "http://<ip-address>:3480/data_request?id=variableget&DeviceNum=33&serviceId=urn:upnp-org:serviceId:SwitchPower1&Variable=Status"
+        },  
+        "setOn": {
+            "url": "http://<ip-address>:3480/data_request?id=action&output_format=xml&DeviceNum=33&serviceId=urn:upnp-org:serviceId:SwitchPower1&action=SetTarget&newTargetValue={value}",
+            "mappers": [
+                {
+                    "type": "static",
+                    "parameters": {
+                        "mapping": {
+                            "false": "0",
+                            "true": "1"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+
+
 ## Plugin Development
 
 To aid in testing and developing this plugin further I have provided a sample homebridge config. This will allow you to spin a homebridge instance for development that has this plugin already installed.  


### PR DESCRIPTION
This is an example that integrates homebridge with a Zwave VERA Edge controller. The getOn function will obtain the status of the switch (a 1 means the switch is on, and a 0 means the switch is off) and will keep polling that, and makes sure that on your homekit switch the status is correctly reflected. When you switch the homekit switch on, it will trigger the setOn, but will first parse through the mapper. If the homekit switch is switched on, it will pass through the word 'true', which the states mapper translates into a 1. This 1 then is passed on (through the variable value) into the url. And obviously for the false, it will map into a 0. The VERA Edge has many commands you can use and are all documented in: http://wiki.mios.com/index.php/Luup_Devices

Note that you do need to replace the word 'ip-address' with your Vera edge ip-address (and make it static in your VERA Edge device, so it stays the same). Then the device number (in this example device 33) you can find in the web interface for your vera device in the devices section (go to a device, and then select advanced).